### PR TITLE
no public url

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,5 +8,4 @@
 # resources from a different path
 
 [context.deploy-preview]
-  publish = "dist/cg-from-scratch"
   command = "npm run build:preview-deploy"

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,4 +8,5 @@
 # resources from a different path
 
 [context.deploy-preview]
+  publish = "dist/cg-from-scratch"
   command = "npm run build:preview-deploy"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
     "build": "parcel build index.html -d dist/cg-from-scratch",
-    "build:preview-deploy": "parcel build index.html --public-url ./cg-from-scratch/", 
+    "build:preview-deploy": "parcel build index.html --public-url ./", 
     "tsx": "tsc"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
     "build": "parcel build index.html -d dist/cg-from-scratch",
-    "build:preview-deploy": "parcel build index.html --public-url ./", 
+    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch --public-url ./cg-from-scratch ", 
     "tsx": "tsc"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
-    "build": "parcel build index.html",
-    "build:preview-deploy": "parcel build index.html", 
+    "build": "parcel build index.html -d dist/cg-from-scratch",
+    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch", 
     "tsx": "tsc"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
     "build": "parcel build index.html -d dist/cg-from-scratch",
-    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch", 
+    "build:preview-deploy": "parcel build index.html --public-url ./cg-from-scratch/ -d dist/cg-from-scratch", 
     "tsx": "tsc"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
-    "build": "parcel build index.html --public-url ./cg-from-scratch/",
+    "build": "parcel build index.html",
     "build:preview-deploy": "parcel build index.html", 
     "tsx": "tsc"
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
     "build": "parcel build index.html -d dist/cg-from-scratch",
-    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch --public-url ./cg-from-scratch ", 
+    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch --public-url . ", 
     "tsx": "tsc"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
-    "build": "parcel build index.html -d dist/cg-from-scratch",
-    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch --public-url . ", 
+    "build": "parcel build index.html -d dist/cg-from-scratch --public-url .",
+    "build:preview-deploy": "parcel build index.html", 
     "tsx": "tsc"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
     "build": "parcel build index.html -d dist/cg-from-scratch",
-    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch", 
+    "build:preview-deploy": "parcel build index.html --public-url ./cg-from-scratch/", 
     "tsx": "tsc"
   },
   "keywords": [],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "dev": "parcel index.html",
     "build": "parcel build index.html -d dist/cg-from-scratch",
-    "build:preview-deploy": "parcel build index.html --public-url ./cg-from-scratch/ -d dist/cg-from-scratch", 
+    "build:preview-deploy": "parcel build index.html -d dist/cg-from-scratch", 
     "tsx": "tsc"
   },
   "keywords": [],


### PR DESCRIPTION
These settings are to ensure that the redirects(rewrites) from the personal-site work as intended.

Hosts index & assets under cg-from-scratch ✅ 
Informs parcel that assets should be relative ✅ 

```
parcel build index.html -d dist/cg-from-scratch --public-url .
```